### PR TITLE
test: add red test

### DIFF
--- a/tests/data/default_style.md
+++ b/tests/data/default_style.md
@@ -469,7 +469,7 @@ Square bracket escapes
 .
 [no-escape]no [no-escape] no [\[\]](/url)
 
-[escape]
+[`code-no-escape`]
 
 [inline\](/url)
 
@@ -483,7 +483,7 @@ Square bracket escapes
 .
 [no-escape]no [no-escape] no [[]](/url)
 
-[escape]
+[`code-no-escape`]
 
 \[inline\](/url)
 


### PR DESCRIPTION
Fixes: #493

The problem appears to be that `escape_square_brackets` is receiving `[]` rather than

```
[`code-no-escape`]
```