### PR TITLE
fix(#507): warn when CLI defaults conflict with TOML

### DIFF
--- a/src/mdformat/_cli.py
+++ b/src/mdformat/_cli.py
@@ -303,29 +303,14 @@ def make_arg_parser(
             plugin.add_cli_argument_group(group)
             for action in group._group_actions:
                 action.dest = f"plugin.{plugin_id}.{action.dest}"
-                if type(action) in {
-                    argparse._StoreTrueAction,
-                    argparse._StoreFalseAction,
-                }:
+                if not (action.default is None or action.default == argparse.SUPPRESS):
                     import warnings
 
-                    is_store_true = type(action) is argparse._StoreTrueAction
-                    plugin_name = (
-                        action.container.title
-                        if hasattr(action, "container")
-                        else str(plugin)
-                    )
-                    text = (
-                        f"For {action.option_strings} from {plugin_name},"
-                        " the default will always override a value configured"
-                        " in TOML. To resolve, replace `.add_argument(...,"
-                        f' action="store_{str(is_store_true).lower()}")` with'
-                        f' `(..., action="store_const", const={is_store_true})`'
-                    )
+                    text = f"The argument default for {action.option_strings} from the '{plugin_id}' plugin, will always override any value configured in TOML. The only supported CLI defaults are `None` or `argparse.SUPPRESS`"  # noqa: E501
                     plugin_file, plugin_line = get_source_file_and_line(action)
                     warnings.warn_explicit(
                         text,
-                        UserWarning,
+                        DeprecationWarning,
                         filename=plugin_file,
                         lineno=plugin_line,
                     )

--- a/src/mdformat/_cli.py
+++ b/src/mdformat/_cli.py
@@ -309,7 +309,7 @@ def make_arg_parser(
                     plugin_file, plugin_line = get_source_file_and_line(plugin)
                     warnings.warn_explicit(
                         f"The `default` ({action.default}) for {action.option_strings} from the '{plugin_id}' plugin, will always override any value configured in TOML. The only supported CLI defaults are `None` or `argparse.SUPPRESS`. To resolve, consider refactoring to `.add_argument(..., default=None)` ",  # noqa: E501
-                        DeprecationWarning,
+                        UserWarning,
                         filename=plugin_file,
                         lineno=plugin_line,
                     )

--- a/src/mdformat/_cli.py
+++ b/src/mdformat/_cli.py
@@ -308,8 +308,8 @@ def make_arg_parser(
 
                     plugin_file, plugin_line = get_source_file_and_line(plugin)
                     warnings.warn_explicit(
-                        f"The `default` ({action.default}) for {action.option_strings} from the '{plugin_id}' plugin, will always override any value configured in TOML. The only supported CLI defaults are `None` or `argparse.SUPPRESS`. To resolve, consider refactoring to `.add_argument(..., default=None)` ",  # noqa: E501
-                        UserWarning,
+                        f"The `default` ({action.default!r}) for {action.option_strings!r} from the {plugin_id!r} plugin, will always override any value configured in TOML. The only supported CLI defaults are `None` or `argparse.SUPPRESS`. To resolve, consider refactoring to `.add_argument(..., default=None)` ",  # noqa: E501
+                        DeprecationWarning,
                         filename=plugin_file,
                         lineno=plugin_line,
                     )

--- a/src/mdformat/_cli.py
+++ b/src/mdformat/_cli.py
@@ -306,13 +306,7 @@ def make_arg_parser(
                 if action.default not in {None, argparse.SUPPRESS}:
                     import warnings
 
-                    text = (
-                        f"The argument default for {action.option_strings}"
-                        f" from the '{plugin_id}' plugin, will always"
-                        " override any value configured in TOML. The only"
-                        " supported CLI defaults are `None` or `argparse."
-                        "SUPPRESS`"
-                    )
+                    text = f"The argument default for {action.option_strings} from the '{plugin_id}' plugin, will always override any value configured in TOML. The only supported CLI defaults are `None` or `argparse.SUPPRESS`"  # noqa: E501
                     plugin_file, plugin_line = get_source_file_and_line(action)
                     warnings.warn_explicit(
                         text,

--- a/src/mdformat/_cli.py
+++ b/src/mdformat/_cli.py
@@ -307,7 +307,7 @@ def make_arg_parser(
                     import warnings
 
                     text = f"The argument default for {action.option_strings} from the '{plugin_id}' plugin, will always override any value configured in TOML. The only supported CLI defaults are `None` or `argparse.SUPPRESS`"  # noqa: E501
-                    plugin_file, plugin_line = get_source_file_and_line(action)
+                    plugin_file, plugin_line = get_source_file_and_line(plugin)
                     warnings.warn_explicit(
                         text,
                         DeprecationWarning,

--- a/src/mdformat/_cli.py
+++ b/src/mdformat/_cli.py
@@ -303,6 +303,27 @@ def make_arg_parser(
             plugin.add_cli_argument_group(group)
             for action in group._group_actions:
                 action.dest = f"plugin.{plugin_id}.{action.dest}"
+                if type(action) in {
+                    argparse._StoreTrueAction,
+                    argparse._StoreFalseAction,
+                }:
+                    import warnings
+
+                    is_store_true = type(action) is argparse._StoreTrueAction
+                    text = (
+                        f"For {action.option_strings} from plugin {plugin},"
+                        "the default will always override a value configured"
+                        "in TOML. To resolve, replace `.add_argument(...,"
+                        f'action="store_{str(is_store_true).lower()}")` with'
+                        f' `(..., action="store_const", const={is_store_true})`'
+                    )
+                    plugin_file, plugin_line = get_source_file_and_line(action)
+                    warnings.warn_explicit(
+                        text,
+                        UserWarning,
+                        filename=plugin_file,
+                        lineno=plugin_line,
+                    )
     return parser
 
 

--- a/src/mdformat/_cli.py
+++ b/src/mdformat/_cli.py
@@ -310,11 +310,16 @@ def make_arg_parser(
                     import warnings
 
                     is_store_true = type(action) is argparse._StoreTrueAction
+                    plugin_name = (
+                        action.container.title
+                        if hasattr(action, "container")
+                        else str(plugin)
+                    )
                     text = (
-                        f"For {action.option_strings} from plugin {plugin},"
-                        "the default will always override a value configured"
-                        "in TOML. To resolve, replace `.add_argument(...,"
-                        f'action="store_{str(is_store_true).lower()}")` with'
+                        f"For {action.option_strings} from {plugin_name},"
+                        " the default will always override a value configured"
+                        " in TOML. To resolve, replace `.add_argument(...,"
+                        f' action="store_{str(is_store_true).lower()}")` with'
                         f' `(..., action="store_const", const={is_store_true})`'
                     )
                     plugin_file, plugin_line = get_source_file_and_line(action)

--- a/src/mdformat/_cli.py
+++ b/src/mdformat/_cli.py
@@ -306,7 +306,13 @@ def make_arg_parser(
                 if not (action.default is None or action.default == argparse.SUPPRESS):
                     import warnings
 
-                    text = f"The argument default for {action.option_strings} from the '{plugin_id}' plugin, will always override any value configured in TOML. The only supported CLI defaults are `None` or `argparse.SUPPRESS`"  # noqa: E501
+                    text = (
+                        f"The argument default for {action.option_strings}"
+                        f" from the '{plugin_id}' plugin, will always"
+                        " override any value configured in TOML. The only"
+                        " supported CLI defaults are `None` or `argparse."
+                        "SUPPRESS`"
+                    )
                     plugin_file, plugin_line = get_source_file_and_line(action)
                     warnings.warn_explicit(
                         text,

--- a/src/mdformat/_cli.py
+++ b/src/mdformat/_cli.py
@@ -306,10 +306,9 @@ def make_arg_parser(
                 if action.default not in {None, argparse.SUPPRESS}:
                     import warnings
 
-                    text = f"The argument default for {action.option_strings} from the '{plugin_id}' plugin, will always override any value configured in TOML. The only supported CLI defaults are `None` or `argparse.SUPPRESS`"  # noqa: E501
                     plugin_file, plugin_line = get_source_file_and_line(plugin)
                     warnings.warn_explicit(
-                        text,
+                        f"The `default` ({action.default}) for {action.option_strings} from the '{plugin_id}' plugin, will always override any value configured in TOML. The only supported CLI defaults are `None` or `argparse.SUPPRESS`. To resolve, consider refactoring to `.add_argument(..., default=None)` ",  # noqa: E501
                         DeprecationWarning,
                         filename=plugin_file,
                         lineno=plugin_line,

--- a/src/mdformat/_cli.py
+++ b/src/mdformat/_cli.py
@@ -303,7 +303,7 @@ def make_arg_parser(
             plugin.add_cli_argument_group(group)
             for action in group._group_actions:
                 action.dest = f"plugin.{plugin_id}.{action.dest}"
-                if not (action.default is None or action.default == argparse.SUPPRESS):
+                if action.default not in {None, argparse.SUPPRESS}:
                     import warnings
 
                     text = (

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -292,7 +292,7 @@ def test_plugin_argument_warnings(monkeypatch, tmp_path):
     file_path.touch()
 
     with patch.object(MDRenderer, "render", return_value=""):
-        with pytest.warns(DeprecationWarning) as warnings:
+        with pytest.warns(UserWarning) as warnings:
             assert run([str(file_path)]) == 0
 
     assert "--store-true" in str(warnings.pop().message)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -272,6 +272,33 @@ dont_override_toml = 'dont override this with None if CLI opt not given'
     )
 
 
+def test_plugin_argument_warnings(monkeypatch, tmp_path):
+    """Test for warnings of plugin arguments that conflict with TOML."""
+
+    class ExamplePluginWithStoreTrue:
+        @staticmethod
+        def update_mdit(mdit: MarkdownIt):
+            pass
+
+        @staticmethod
+        def add_cli_argument_group(group: argparse._ArgumentGroup) -> None:
+            group.add_argument("--store-true", action="store_true")
+            group.add_argument("--store-false", action="store_false")
+            group.add_argument("--store-const", action="store_const", const=True)
+
+    monkeypatch.setitem(PARSER_EXTENSIONS, "table", ExamplePluginWithStoreTrue)
+    file_path = tmp_path / "test_markdown.md"
+    file_path.touch()
+
+    with patch.object(MDRenderer, "render", return_value=""):
+        with pytest.warns(UserWarning) as warnings:
+            assert run([str(file_path)]) == 0
+
+    assert "store_true" in str(warnings.pop().message)
+    assert "store_false" in str(warnings.pop().message)
+    assert len(warnings) == 0
+
+
 def test_cli_options_group__no_toml(monkeypatch, tmp_path):
     """Test add_cli_argument_group plugin API with configuration only from
     CLI."""

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -292,7 +292,7 @@ def test_plugin_argument_warnings(monkeypatch, tmp_path):
     file_path.touch()
 
     with patch.object(MDRenderer, "render", return_value=""):
-        with pytest.warns(UserWarning) as warnings:
+        with pytest.warns(DeprecationWarning) as warnings:
             assert run([str(file_path)]) == 0
 
     assert "--store-true" in str(warnings.pop().message)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -284,6 +284,7 @@ def test_plugin_argument_warnings(monkeypatch, tmp_path):
         def add_cli_argument_group(group: argparse._ArgumentGroup) -> None:
             group.add_argument("--store-true", action="store_true")
             group.add_argument("--store-false", action="store_false")
+            group.add_argument("--store-zero", default=0)
             group.add_argument("--store-const", action="store_const", const=True)
 
     monkeypatch.setitem(PARSER_EXTENSIONS, "table", ExamplePluginWithStoreTrue)
@@ -291,11 +292,12 @@ def test_plugin_argument_warnings(monkeypatch, tmp_path):
     file_path.touch()
 
     with patch.object(MDRenderer, "render", return_value=""):
-        with pytest.warns(UserWarning) as warnings:
+        with pytest.warns(DeprecationWarning) as warnings:
             assert run([str(file_path)]) == 0
 
-    assert "store_true" in str(warnings.pop().message)
-    assert "store_false" in str(warnings.pop().message)
+    assert "--store-true" in str(warnings.pop().message)
+    assert "--store-false" in str(warnings.pop().message)
+    assert "--store-zero" in str(warnings.pop().message)
     assert len(warnings) == 0
 
 


### PR DESCRIPTION
Fixes #507

Adds a user-warning when plugins have argument defaults that conflict with the new TOML config

```
> uv tool install . --editable --force --with="mdformat-mkdocs[recommended]==4.1.1"
> mdformat --version
/Users/kyleking/.local/share/uv/tools/mdformat/lib/python3.13/site-packages/mdformat_mkdocs/__init__.py:0: UserWarning: The `default` (False) for ['--align-semantic-breaks-in-lists'] from the 'mkdocs' plugin, will always override any value configured in TOML. The only supported CLI defaults are `None` or `argparse.SUPPRESS`. To resolve, consider refactoring to `.add_argument(..., default=None)` 
/Users/kyleking/.local/share/uv/tools/mdformat/lib/python3.13/site-packages/mdformat_mkdocs/__init__.py:0: UserWarning: The `default` (False) for ['--ignore-missing-references'] from the 'mkdocs' plugin, will always override any value configured in TOML. The only supported CLI defaults are `None` or `argparse.SUPPRESS`. To resolve, consider refactoring to `.add_argument(..., default=None)`
mdformat 0.7.22 (mdformat_frontmatter 2.0.8, mdformat-gfm 0.4.1, mdformat_simple_breaks 0.0.1, mdformat_tables 1.0.0, mdformat_mkdocs 4.1.1, mdformat_footnote 0.1.1, mdformat_wikilink 0.2.0, mdformat-config 0.2.1, mdformat-web 0.2.0, mdformat-beautysh 0.1.1, mdformat-ruff 0.1.3)
```

**Edit**: the example STDERR above was updated to reflect the implementation changes