### PR TITLE
Fix stdin encoding

### DIFF
--- a/docs/users/changelog.md
+++ b/docs/users/changelog.md
@@ -3,10 +3,11 @@
 This log documents all Python API or CLI breaking backwards incompatible changes.
 Note that there is currently no guarantee for a stable Markdown formatting style across versions.
 
-## Develop
+## **unreleased**
 
-- Use consistent encoding when reading from stdin.
-  It is now read with UTF-8 encoding, consistent with the encoding used in writing.
+- Fixed
+  - Read UTF-8 from standard input on all systems.
+    Thank you, [Christopher Prohm](https://github.com/chmp), for the PR.
 
 ## 0.7.22
 

--- a/docs/users/changelog.md
+++ b/docs/users/changelog.md
@@ -3,6 +3,11 @@
 This log documents all Python API or CLI breaking backwards incompatible changes.
 Note that there is currently no guarantee for a stable Markdown formatting style across versions.
 
+## Develop
+
+- Use consistent encoding when reading from stdin.
+  It is now read with UTF-8 encoding, consistent with the encoding used in writing.
+
 ## 0.7.22
 
 - Performance

--- a/docs/users/style.md
+++ b/docs/users/style.md
@@ -12,6 +12,8 @@ formatted Markdown should yield a result that is visually identical to the unfor
 Mdformat CLI includes a safety check that will error and refuse to apply changes to a file
 if Markdown AST is not equal before and after formatting.
 
+Mdformat reads and writes all files with Utf-8 encoding.
+
 ## Headings
 
 For consistency, only ATX headings are used.

--- a/docs/users/style.md
+++ b/docs/users/style.md
@@ -12,8 +12,6 @@ formatted Markdown should yield a result that is visually identical to the unfor
 Mdformat CLI includes a safety check that will error and refuse to apply changes to a file
 if Markdown AST is not equal before and after formatting.
 
-Mdformat reads and writes all files with Utf-8 encoding.
-
 ## Headings
 
 For consistency, only ATX headings are used.

--- a/src/mdformat/_cli.py
+++ b/src/mdformat/_cli.py
@@ -148,7 +148,7 @@ def run(cli_args: Sequence[str], cache_toml: bool = True) -> int:  # noqa: C901
                 print_error(f'File "{path_str}" is not formatted.')
         else:
             changes_ast = any(
-                getattr(plugin, 'CHANGES_AST', False)
+                getattr(plugin, "CHANGES_AST", False)
                 for plugin in enabled_parserplugins.values()
             )
             if (

--- a/src/mdformat/_cli.py
+++ b/src/mdformat/_cli.py
@@ -124,7 +124,7 @@ def run(cli_args: Sequence[str], cache_toml: bool = True) -> int:  # noqa: C901
             original_str = path.read_bytes().decode()
         else:
             path_str = "-"
-            original_str = sys.stdin.read()
+            original_str = sys.stdin.buffer.read().decode()
 
         # Lazy import to improve module import time
         from mdformat.renderer import LOGGER as RENDERER_LOGGER

--- a/src/mdformat/_cli.py
+++ b/src/mdformat/_cli.py
@@ -148,7 +148,7 @@ def run(cli_args: Sequence[str], cache_toml: bool = True) -> int:  # noqa: C901
                 print_error(f'File "{path_str}" is not formatted.')
         else:
             changes_ast = any(
-                getattr(plugin, "CHANGES_AST", False)
+                getattr(plugin, 'CHANGES_AST', False)
                 for plugin in enabled_parserplugins.values()
             )
             if (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+import io
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def patch_stdin(monkeypatch):
+    """Fixture to patch sys.stdin for the running test"""
+    def set_stdin(text):
+        buffer = io.BytesIO(text.encode())
+        fobj = io.TextIOWrapper(buffer)
+        monkeypatch.setattr(sys, "stdin", fobj)
+    
+    return set_stdin

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,9 +7,10 @@ import pytest
 @pytest.fixture
 def patch_stdin(monkeypatch):
     """Fixture to patch sys.stdin for the running test"""
+
     def set_stdin(text):
         buffer = io.BytesIO(text.encode())
         fobj = io.TextIOWrapper(buffer)
         monkeypatch.setattr(sys, "stdin", fobj)
-    
+
     return set_stdin

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 
 @pytest.fixture
 def patch_stdin(monkeypatch):
-    """Fixture to patch sys.stdin for the running test"""
+    """Fixture to patch sys.stdin for the running test."""
 
     def set_stdin(text):
         buffer = io.BytesIO(text.encode())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,3 @@
-from io import StringIO
 import os
 import sys
 from unittest.mock import patch

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -143,8 +143,8 @@ def test_formatter_plugin(tmp_path, monkeypatch):
     assert file_path.read_text() == "```lang\ndummy\n```\n"
 
 
-def test_dash_stdin(capfd, monkeypatch):
-    monkeypatch.setattr(sys, "stdin", StringIO(UNFORMATTED_MARKDOWN))
+def test_dash_stdin(capfd, patch_stdin):
+    patch_stdin(UNFORMATTED_MARKDOWN)
     assert run(("-",)) == 0
     captured = capfd.readouterr()
     assert captured.out == FORMATTED_MARKDOWN
@@ -298,8 +298,8 @@ def test_eol__keep_crlf(tmp_path):
     assert file_path.read_bytes() == b"Oi\r\n"
 
 
-def test_eol__crlf_stdin(capfd, monkeypatch):
-    monkeypatch.setattr(sys, "stdin", StringIO("Oi\n"))
+def test_eol__crlf_stdin(capfd, patch_stdin):
+    patch_stdin("Oi\n")
     assert run(["-", "--end-of-line=crlf"]) == 0
     captured = capfd.readouterr()
     assert captured.out == "Oi\r\n"

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -90,11 +90,11 @@ def test_invalid_conf_value(bad_conf, conf_key, tmp_path, capsys):
     assert f"Invalid '{conf_key}' value" in captured.err
 
 
-def test_conf_with_stdin(tmp_path, capfd, monkeypatch):
+def test_conf_with_stdin(tmp_path, capfd, patch_stdin):
     config_path = tmp_path / ".mdformat.toml"
     config_path.write_text("number = true")
 
-    monkeypatch.setattr(sys, "stdin", StringIO("1. one\n1. two\n1. three"))
+    patch_stdin("1. one\n1. two\n1. three")
 
     with mock.patch("mdformat._cli.Path.cwd", return_value=tmp_path):
         assert run(("-",), cache_toml=False) == 0

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -1,4 +1,3 @@
-from io import StringIO
 import sys
 from unittest import mock
 


### PR DESCRIPTION
Change: Use utf8-encoding when reading files from stdin. 

The current code uses stdout.buffer.read() + encode for writing, which implies Utf8 encoding, but uses stdin.read(), which uses an environment specific encoding. See [docs](https://docs.python.org/3/library/sys.html#sys.stdin).

I ran into this issue when using Mdformat with Helix on Windows. For files with German content and Utf8-encoding the current code mangled any non-ascii characters. The proposed code fixed this behavior.