### PR TITLE
Add CLI option to specify config file

### DIFF
--- a/src/mdformat/_cli.py
+++ b/src/mdformat/_cli.py
@@ -47,6 +47,8 @@ def run(cli_args: Sequence[str], cache_toml: bool = True) -> int:  # noqa: C901
     renderer_warning_printer = RendererWarningPrinter()
     for path in file_paths:
         read_toml = read_toml_opts if cache_toml else read_toml_opts.__wrapped__
+        if cli_opts.get("toml_file"):
+            path = Path(cli_opts["toml_file"])
         try:
             toml_opts, toml_path = read_toml(path.parent if path else Path.cwd())
         except InvalidConfError as e:
@@ -282,6 +284,10 @@ def make_arg_parser(
         const=(),
         dest="codeformatters",
         help=argparse.SUPPRESS,
+    )
+    codeformatters_group.add_argument(
+        "--toml_file",
+        help="path to desired toml config file",
     )
     for plugin in parser_extensions.values():
         if hasattr(plugin, "add_cli_options"):

--- a/src/mdformat/_cli.py
+++ b/src/mdformat/_cli.py
@@ -52,7 +52,7 @@ def run(cli_args: Sequence[str], cache_toml: bool = True) -> int:  # noqa: C901
         if path:
             conf_dir = path.parent
         if cli_opts.get("toml_file"):
-            cli_toml_file = resolve_cli_toml_file(cli_opts)
+            cli_toml_file = resolve_cli_toml_file(cli_opts["toml_file"])
             conf_dir = cli_toml_file.parent
 
         try:
@@ -514,15 +514,14 @@ def get_source_file_and_line(obj: object) -> tuple[str, int]:
     return filename, lineno
 
 
-def resolve_cli_toml_file(cli_opts):
-    cli_toml: str = cli_opts["toml_file"]
+def resolve_cli_toml_file(cli_toml_arg: str) -> Path:
+    toml_file = Path(cli_toml_arg).absolute()
 
-    if cli_toml[0].isalnum() or cli_toml[0] in ["."]:
-        toml_file = (Path.cwd() / cli_toml).absolute()
-    elif cli_toml[0] == "~":
-        toml_file = (Path.home() / cli_toml[1:]).absolute()
-    else:
-        toml_file = Path(cli_toml).absolute()
+    if cli_toml_arg[0].isalnum() or (cli_toml_arg[0] in ["."]):
+        toml_file = (Path.cwd() / cli_toml_arg).absolute()
+
+    if cli_toml_arg[0] == "~":
+        toml_file = (Path.home() / cli_toml_arg.replace("~", "")).absolute()
 
     if not toml_file.is_file():
         raise InvalidPath(toml_file)

--- a/src/mdformat/_cli.py
+++ b/src/mdformat/_cli.py
@@ -257,6 +257,7 @@ def make_arg_parser(
             help="exclude files that match the Unix-style glob pattern "
             "(multiple allowed)",
         )
+    parser.add_argument("--toml_file", help="path to desired toml config file")
     extensions_group = parser.add_mutually_exclusive_group()
     extensions_group.add_argument(
         "--extensions",
@@ -290,10 +291,6 @@ def make_arg_parser(
         const=(),
         dest="codeformatters",
         help=argparse.SUPPRESS,
-    )
-    codeformatters_group.add_argument(
-        "--toml_file",
-        help="path to desired toml config file",
     )
     for plugin in parser_extensions.values():
         if hasattr(plugin, "add_cli_options"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -513,3 +513,13 @@ def test_no_extensions(tmp_path, monkeypatch):
     file_path.write_text(original_md)
     assert run((str(file_path), "--no-extensions")) == 0
     assert file_path.read_text() == original_md
+
+
+def test_cli_toml(tmp_path):
+    config_path = tmp_path / ".mdformat.toml"
+    config_path.write_text("wrap = 20")
+
+    file_path = tmp_path / "test_markdown.md"
+    file_path.write_text("".join(["x" * 20, "o" * 20, "w" * 20, "p" * 20]))
+    assert run([str(file_path), "--wrap=60"]) == 0
+    assert file_path.read_text() == "\n".join(["x" * 20, "o" * 20, "w" * 20, "p" * 20])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -530,7 +530,7 @@ def test_cli_toml(tmp_path):
     assert file_path.read_text() == "xxxxx\nooooo\nwwwww\nppppp\n"
 
 
-def test_cli_toml_alpanum(tmp_path):
+def test_cli_toml_alphanum(tmp_path):
     config_path = "1234/.mdformat.toml"
 
     file_path = tmp_path / "test_markdown.md"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -516,10 +516,11 @@ def test_no_extensions(tmp_path, monkeypatch):
 
 
 def test_cli_toml(tmp_path):
-    config_path = tmp_path / ".mdformat.toml"
+    config_path = tmp_path / "sub/.mdformat.toml"
     config_path.write_text("wrap = 20")
 
     file_path = tmp_path / "test_markdown.md"
     file_path.write_text("".join(["x" * 20, "o" * 20, "w" * 20, "p" * 20]))
-    assert run([str(file_path), "--wrap=60"]) == 0
+
+    assert run([str(file_path), f"--toml_file={config_path}"]) == 0
     assert file_path.read_text() == "\n".join(["x" * 20, "o" * 20, "w" * 20, "p" * 20])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -516,11 +516,14 @@ def test_no_extensions(tmp_path, monkeypatch):
 
 
 def test_cli_toml(tmp_path):
-    config_path = tmp_path / "cli.toml"
-    config_path.write_text("wrap = 20")
+    _wrap_num = 5
+    config_path = tmp_path / ".mdformat.toml"
+    config_path.write_text(f"wrap = {_wrap_num}")
 
     file_path = tmp_path / "test_markdown.md"
-    file_path.write_text("".join(["x" * 20, "o" * 20, "w" * 20, "p" * 20]))
+    file_path.write_text(
+        " ".join(["x" * _wrap_num, "o" * _wrap_num, "w" * _wrap_num, "p" * _wrap_num])
+    )
 
     assert run([str(file_path), f"--toml_file={config_path}"]) == 0
-    assert file_path.read_text() == "\n".join(["x" * 20, "o" * 20, "w" * 20, "p" * 20])
+    assert file_path.read_text() == "xxxxx\nooooo\nwwwww\nppppp\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -516,7 +516,7 @@ def test_no_extensions(tmp_path, monkeypatch):
 
 
 def test_cli_toml(tmp_path):
-    config_path = tmp_path / "sub/.mdformat.toml"
+    config_path = tmp_path / "cli.toml"
     config_path.write_text("wrap = 20")
 
     file_path = tmp_path / "test_markdown.md"


### PR DESCRIPTION
Closes #432 

- CLI now has option `--toml_file` to specify a path to a `.mdformat.toml` file
  - file name must be `.mdformat.toml`
- Partial path supplied to CLI will resolve with a couple different options
  - Defaults to current working directory
    - Ex. `--toml_file=.mdformat.toml` -> `/path/to/cwd/.mdformat.toml`
    - Ex. `--toml_file=cool_directory/.mdformat.toml` -> `/path/to/cwd/cool_directory/.mdformat.toml`
  - Using `~` at beginning of argument will using the user's home directory
    - Ex. `--toml_file=~/.mdformat.toml` -> `/path/to/user/home/.mdformat.toml`
    - Ex. `--toml_file=~/cool_directory/.mdformat.toml` -> `/path/to/user/homt/cool_directory/.mdformat.toml`
