### PR TITLE
fix: use split('\n') instead of splitlines() in blockquote renderer

### DIFF
--- a/src/mdformat/renderer/_context.py
+++ b/src/mdformat/renderer/_context.py
@@ -326,7 +326,7 @@ def blockquote(node: RenderTreeNode, context: RenderContext) -> str:
     marker = "> "
     with context.indented(len(marker)):
         text = make_render_children(separator="\n\n")(node, context)
-        lines = text.splitlines()
+        lines = text.split("\n")
         if not lines:
             return ">"
         quoted_lines = (f"{marker}{line}" if line else ">" for line in lines)


### PR DESCRIPTION
Blockquote rendering in mdformat is non-idempotent when the content
contains Unicode whitespace characters like form feed (`\x0c`),
vertical tab (`\x0b`), or Unicode line separators.

`f(f(x)) != f(x)` — the first format pass produces semantically
different output from the input. The second pass normalizes it.

**Minimal reproduction:**
```python
import mdformat
pass1 = mdformat.text('>a\x0c\t6')
pass2 = mdformat.text(pass1)
assert pass1 == pass2  # FAILS
```

**Root cause:** `blockquote()` in `_context.py` uses
`text.splitlines()` which splits on Unicode line separators that
CommonMark does not recognize. The other renderers (`paragraph`,
`list_item`) correctly use `text.split("\n")`.

**Fix (+1/-1):** `text.splitlines()` → `text.split("\n")` — brings
blockquote in line with paragraph and list_item.

4282/4282 tests pass (5 skipped pre-existing).
211/211 idempotence fuzz tests pass.

This pull request was prepared with the assistance of AI, under my
direction and review.
