### PR TITLE
Escape `"` in image titles (#586)

### DIFF
--- a/src/mdformat/renderer/_context.py
+++ b/src/mdformat/renderer/_context.py
@@ -218,6 +218,8 @@ def image(node: RenderTreeNode, context: RenderContext) -> str:
     uri = maybe_add_link_brackets(uri)
     title = node.attrs.get("title")
     if title is not None:
+        assert isinstance(title, str)
+        title = title.replace('"', '\\"')
         return f'![{description}]({uri} "{title}")'
     return f"![{description}]({uri})"
 

--- a/tests/data/default_style.md
+++ b/tests/data/default_style.md
@@ -130,6 +130,17 @@ references:
 [ref2]: link3 "title"
 .
 
+link and image titles with embedded quotes
+.
+[text](link1 "a \"quoted\" title")
+
+![text](img.png "a \"quoted\" title")
+.
+[text](link1 "a \"quoted\" title")
+
+![text](img.png "a \"quoted\" title")
+.
+
 thematic breaks
 .
 something something


### PR DESCRIPTION
Fixes #586.

## Root cause

`image()` in `src/mdformat/renderer/_context.py` writes `node.attrs["title"]` straight into the `(uri "title")` form without escaping embedded double quotes:

```python
title = node.attrs.get("title")
if title is not None:
    return f'![{description}]({uri} "{title}")'
```

`link()`, a few lines below, already handles this correctly:

```python
title = title.replace('"', '\\"')
return f'[{text}]({uri} "{title}")'
```

An unescaped `"` in an image title closes the title early, producing malformed Markdown, and makes `mdformat.text()` non-idempotent on such input — reformatting the (already malformed) output a second time reparses it differently and even escapes the image's own brackets.

Reproduced exactly as described in the issue:
```python
src = '![alt](img.png "a \\"quoted\\" title")'
mdformat.text(src)   # -> '![alt](img.png "a "quoted" title")\n'  (title truncated)
mdformat.text(out)   # -> '!\\[alt\\](img.png "a "quoted" title")\n'  (not idempotent)
```

## Fix

Mirror `link()`'s escaping in `image()`.

## Tests

Added a `link and image titles with embedded quotes` case to `tests/data/default_style.md` covering both link and image titles with an embedded, escaped quote. Confirmed this case fails against the unfixed code — `mdformat._cli.run()` actually raises `Could not format ...: Formatted Markdown renders to different HTML than input Markdown`, mdformat's own consistency check catching the corruption — and passes after the fix. Full test suite: 4286 passed, 1 skipped, 0 failures.