### PR TITLE
Make the Sphinx sidebar logo render sharp

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # a list of builtin themes.
 #
 html_theme = 'furo'
-html_logo = "_static/logo-150px.png"
+html_logo = "_static/logo.svg"
 html_show_sphinx = False
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
This patch changes the logo injected into the Sphinx docs from PNG to SVG. PNG gets pixelated on scaling for no good reason, while vector graphics remains nice regardless of the zoom level applied.

---

The pre-commit.ci status check failure is obviously unrelated.

The PR docs build preview @ https://mdformat--592.org.readthedocs.build/en/592/ shows a nicer pic in the sidebar. You may want to apply some spacing around the image, but I've made this in 2 minutes in-browser as a drive-by PoC. Please feel free to take over and complete the PR to the shape you like. Cheers!